### PR TITLE
update test instructions to use configured wallet RPC port

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Running the [top-level API tests](./src/HavenoDaemon.test.tsx) is a great way to
 4. In a new terminal, start an instance of monero-wallet-rpc at port 38084. This wallet will be automatically funded in order to fund Alice and Bob during the tests.<br>For example: `cd ~/git/haveno/.localnet/ && ./monero-wallet-rpc --daemon-address http://localhost:38081 --daemon-login superuser:abctesting123 --stagenet --rpc-bind-port 38084 --rpc-login rpc_user:abc123 --wallet-dir ./ --rpc-access-control-origins http://localhost:8080`
 5. `cd haveno-ui-poc`
 6. `npm install`
-7. Modify test config as needed in [HavenoDaemon.test.ts](./src/HavenoDaemon.test.ts).<br>The tests need to know the port of Alice's wallet, which is printed to Alice's console. Currently the port needs to be manually copied to the test configuration.
-8. `npm test` to run all tests or `npm run test -- -t 'my test'` to run tests by name.
+7. `npm test` to run all tests or `npm run test -- -t 'my test'` to run tests by name.
+
 
 ## How to Update the Protobuf Client
 

--- a/src/HavenoDaemon.test.ts
+++ b/src/HavenoDaemon.test.ts
@@ -29,7 +29,7 @@ const havenoVersion = "1.6.2";
 const aliceDaemonUrl = "http://localhost:8080";
 const aliceDaemonPassword = "apitest";
 const alice: HavenoDaemon = new HavenoDaemon(aliceDaemonUrl, aliceDaemonPassword);
-const aliceWalletUrl = "http://127.0.0.1:64840"; // alice's internal haveno wallet for direct testing // TODO (woodser): make configurable rather than randomly generated
+const aliceWalletUrl = "http://127.0.0.1:38091"; // alice's internal haveno wallet for direct testing
 const aliceWalletUsername = "rpc_user";
 const aliceWalletPassword = "abc123";
 let aliceWallet: any;


### PR DESCRIPTION
This should simplify running the tests using a predefined port removing the need to copy paste the port after starting alice-daemon

Implemented in https://github.com/haveno-dex/haveno/pull/163