### PR TITLE
Updates README with protoc-gen-grpc-web instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ This application is a lightly modified [create-react-app](https://github.com/fac
 4. Install protobuf for your system:<br>
     mac: `brew install protobuf`<br>
     linux: `apt install protobuf-compiler`
-5. `cd haveno-ui-poc`
-6. `npm install`
-7. `npm start` to open http://localhost:3000 in a browser
-8. Confirm that the Haveno daemon version is displayed (1.6.2)
+5.  Download `protoc-gen-grpc-web` plugin and make executable as [shown here](https://github.com/grpc/grpc-web#code-generator-plugin)
+6. `cd haveno-ui-poc`
+7. `npm install`
+8. `npm start` to open http://localhost:3000 in a browser
+9. Confirm that the Haveno daemon version is displayed (1.6.2)
 
 <p align="center">
     <img src="haveno-ui-poc.png" width="500"/><br>
@@ -34,6 +35,7 @@ Running the [top-level API tests](./src/HavenoDaemon.test.tsx) is a great way to
 5. Install protobuf for your system:<br>
     mac: `brew install protobuf`<br>
     linux: `apt install protobuf-compiler`
-6. `cd haveno-ui-poc`
-7. `npm install`
-8. `npm test` to run all tests or `npm run test -- -t 'my test'` to run tests by name.
+6. Download `protoc-gen-grpc-web` plugin and make executable as [shown here](https://github.com/grpc/grpc-web#code-generator-plugin)
+7. `cd haveno-ui-poc`
+8. `npm install`
+9. `npm test` to run all tests or `npm run test -- -t 'my test'` to run tests by name.


### PR DESCRIPTION
This updates the readme to address a new error me and yersinia_p3s1s were having with `protoc-gen-grpc-web` when running `npm install`.

Adds an instruction to make it clear what is required to run.