### PR TITLE
Eslint - fix 'proto' is not defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "extends": [
       "react-app",
       "react-app/jest"
-    ]
+    ],
+    "ignorePatterns": ["**/*_pb.js"]
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
I was getting same output like described [here](https://github.com/grpc/grpc-web/issues/447). This pull request fixes it.