### PR TITLE
Add API functions to register arbitrator and mediator keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This application is a lightly modified [create-react-app](https://github.com/fac
 1. [Run a local Haveno test network](https://github.com/haveno-dex/haveno/blob/master/docs/installing.md), running Alice as a daemon with `make alice-daemon`.
 2. Clone this project to the same parent directory as the haveno project: `git clone https://github.com/haveno-dex/haveno-ui-poc`
 3. In a new terminal, start envoy with the config in haveno-ui-poc/config/envoy.yaml (change absolute path for your system): `docker run --rm --add-host host.docker.internal:host-gateway -it -v ~/git/haveno-ui-poc/config/envoy.yaml:/envoy.yaml -p 8080:8080 envoyproxy/envoy-dev:8a2143613d43d17d1eb35a24b4a4a4c432215606 -c /envoy.yaml`
-4. Install protobuf compiler 3.19.1 or later for your system:<br>
+4. Install protobuf compiler v3.19.1 or later for your system:<br>
     mac: `brew install protobuf`<br>
     linux: `apt install protobuf-compiler`
     NOTE: You may need to upgrade to v3.19.1 manually if your package manager installs an older version.
@@ -33,7 +33,7 @@ Running the [top-level API tests](./src/HavenoDaemon.test.ts) is a great way to 
 2. Clone this project to the same parent directory as the haveno project: `git clone https://github.com/haveno-dex/haveno-ui-poc`
 3. In a new terminal, start envoy with the config in haveno-ui-poc/config/envoy.test.yaml (change absolute path for your system): `docker run --rm --add-host host.docker.internal:host-gateway -it -v ~/git/haveno-ui-poc/config/envoy.test.yaml:/envoy.test.yaml -p 8079:8079 -p 8080:8080 -p 8081:8081 -p 8082:8082 -p 8083:8083 -p 8084:8084 -p 8085:8085 -p 8086:8086 envoyproxy/envoy-dev:8a2143613d43d17d1eb35a24b4a4a4c432215606 -c /envoy.test.yaml`
 4. In a new terminal, start the funding wallet. This wallet will be automatically funded in order to fund Alice and Bob during the tests.<br>For example: `cd ~/git/haveno && make funding-wallet`.
-5. Install protobuf compiler 3.19.1 or later for your system:<br>
+5. Install protobuf compiler v3.19.1 or later for your system:<br>
     mac: `brew install protobuf`<br>
     linux: `apt install protobuf-compiler`
     NOTE: You may need to upgrade to v3.19.1 manually if your package manager installs an older version.
@@ -41,5 +41,3 @@ Running the [top-level API tests](./src/HavenoDaemon.test.ts) is a great way to 
 7. `cd haveno-ui-poc`
 8. `npm install`
 9. `npm test` to run all tests or `npm run test -- -t 'my test'` to run tests by name.
-
-

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This application is a lightly modified [create-react-app](https://github.com/fac
 4. Install protobuf compiler 3.19.1 or later for your system:<br>
     mac: `brew install protobuf`<br>
     linux: `apt install protobuf-compiler`
+    NOTE: You may need to upgrade to v3.19.1 manually if your package manager installs an older version.
 5.  Download `protoc-gen-grpc-web` plugin and make executable as [shown here](https://github.com/grpc/grpc-web#code-generator-plugin).
 6. `cd haveno-ui-poc`
 7. `npm install`
@@ -28,14 +29,17 @@ Running the [top-level API tests](./src/HavenoDaemon.test.ts) is a great way to 
 
 [`HavenoDaemon`](./src/HavenoDaemon.ts) provides the interface to the Haveno daemon's gRPC API.
 
-1. [Run a local Haveno test network](https://github.com/haveno-dex/haveno/blob/master/docs/installing.md) and then shut down the arbitrator, Alice, and Bob or run them as daemons, e.g. `make alice-daemon`.
+1. [Run a local Haveno test network](https://github.com/haveno-dex/haveno/blob/master/docs/installing.md) and then shut down the arbitrator, Alice, and Bob or run them as daemons, e.g. `make alice-daemon`. You may omit the arbitrator registration steps since it is done automatically in the tests.
 2. Clone this project to the same parent directory as the haveno project: `git clone https://github.com/haveno-dex/haveno-ui-poc`
 3. In a new terminal, start envoy with the config in haveno-ui-poc/config/envoy.test.yaml (change absolute path for your system): `docker run --rm --add-host host.docker.internal:host-gateway -it -v ~/git/haveno-ui-poc/config/envoy.test.yaml:/envoy.test.yaml -p 8079:8079 -p 8080:8080 -p 8081:8081 -p 8082:8082 -p 8083:8083 -p 8084:8084 -p 8085:8085 -p 8086:8086 envoyproxy/envoy-dev:8a2143613d43d17d1eb35a24b4a4a4c432215606 -c /envoy.test.yaml`
 4. In a new terminal, start the funding wallet. This wallet will be automatically funded in order to fund Alice and Bob during the tests.<br>For example: `cd ~/git/haveno && make funding-wallet`.
 5. Install protobuf compiler 3.19.1 or later for your system:<br>
     mac: `brew install protobuf`<br>
     linux: `apt install protobuf-compiler`
+    NOTE: You may need to upgrade to v3.19.1 manually if your package manager installs an older version.
 6. Download `protoc-gen-grpc-web` plugin and make executable as [shown here](https://github.com/grpc/grpc-web#code-generator-plugin).
 7. `cd haveno-ui-poc`
 8. `npm install`
 9. `npm test` to run all tests or `npm run test -- -t 'my test'` to run tests by name.
+
+

--- a/src/HavenoDaemon.ts
+++ b/src/HavenoDaemon.ts
@@ -1,7 +1,7 @@
 import {HavenoUtils} from "./HavenoUtils";
 import * as grpcWeb from 'grpc-web';
-import {DisputeAgentsClient, GetVersionClient, PriceClient, WalletsClient, OffersClient, PaymentAccountsClient, TradesClient} from './protobuf/GrpcServiceClientPb';
-import {GetVersionRequest, GetVersionReply, MarketPriceRequest, MarketPriceReply, MarketPricesRequest, MarketPricesReply, MarketPriceInfo, GetBalancesRequest, GetBalancesReply, XmrBalanceInfo, GetOffersRequest, GetOffersReply, OfferInfo, GetPaymentAccountsRequest, GetPaymentAccountsReply, CreateCryptoCurrencyPaymentAccountRequest, CreateCryptoCurrencyPaymentAccountReply, CreateOfferRequest, CreateOfferReply, CancelOfferRequest, TakeOfferRequest, TakeOfferReply, TradeInfo, GetTradeRequest, GetTradeReply, GetTradesRequest, GetTradesReply, GetNewDepositSubaddressRequest, GetNewDepositSubaddressReply, ConfirmPaymentStartedRequest, ConfirmPaymentReceivedRequest, XmrTx, GetXmrTxsRequest, GetXmrTxsReply, XmrDestination, CreateXmrTxRequest, CreateXmrTxReply, RelayXmrTxRequest, RelayXmrTxReply, RegisterDisputeAgentRequest} from './protobuf/grpc_pb';
+import {GetVersionClient, DisputeAgentsClient, PriceClient, WalletsClient, OffersClient, PaymentAccountsClient, TradesClient} from './protobuf/GrpcServiceClientPb';
+import {GetVersionRequest, GetVersionReply, RegisterDisputeAgentRequest, MarketPriceRequest, MarketPriceReply, MarketPricesRequest, MarketPricesReply, MarketPriceInfo, GetBalancesRequest, GetBalancesReply, XmrBalanceInfo, GetOffersRequest, GetOffersReply, OfferInfo, GetPaymentAccountsRequest, GetPaymentAccountsReply, CreateCryptoCurrencyPaymentAccountRequest, CreateCryptoCurrencyPaymentAccountReply, CreateOfferRequest, CreateOfferReply, CancelOfferRequest, TakeOfferRequest, TakeOfferReply, TradeInfo, GetTradeRequest, GetTradeReply, GetTradesRequest, GetTradesReply, GetNewDepositSubaddressRequest, GetNewDepositSubaddressReply, ConfirmPaymentStartedRequest, ConfirmPaymentReceivedRequest, XmrTx, GetXmrTxsRequest, GetXmrTxsReply, XmrDestination, CreateXmrTxRequest, CreateXmrTxReply, RelayXmrTxRequest, RelayXmrTxReply} from './protobuf/grpc_pb';
 import {PaymentAccount, AvailabilityResult} from './protobuf/pb_pb';
 const console = require('console');
 
@@ -17,12 +17,12 @@ class HavenoDaemon {
   _processLogging: boolean = false;
   _walletRpcPort: number|undefined;
   _getVersionClient: GetVersionClient;
+  _disputeAgentsClient: DisputeAgentsClient;
   _priceClient: PriceClient;
   _walletsClient: WalletsClient;
   _paymentAccountsClient: PaymentAccountsClient;
   _offersClient: OffersClient;
   _tradesClient: TradesClient;
-  _disputeAgentsClient: DisputeAgentsClient;
   
   /**
    * Construct a client connected to a Haveno daemon.
@@ -37,12 +37,12 @@ class HavenoDaemon {
     this._url = url;
     this._password = password;
     this._getVersionClient = new GetVersionClient(this._url);
+    this._disputeAgentsClient = new DisputeAgentsClient(this._url);
     this._priceClient = new PriceClient(this._url);
     this._walletsClient = new WalletsClient(this._url);
     this._paymentAccountsClient = new PaymentAccountsClient(this._url);
     this._offersClient = new OffersClient(this._url);
     this._tradesClient = new TradesClient(this._url);
-    this._disputeAgentsClient = new DisputeAgentsClient(this._url);
   }
   
   /**
@@ -202,6 +202,25 @@ class HavenoDaemon {
   }
   
   /**
+   * Register as a dispute agent.
+   * 
+   * @param {string} disputeAgentType - type of dispute agent to register, e.g. mediator, refundagent
+   * @param {string} registrationKey - registration key
+   */
+  async registerDisputeAgent(disputeAgentType: string, registrationKey: string): Promise<void> {
+    let that = this;
+    let request = new RegisterDisputeAgentRequest()
+        .setDisputeAgentType(disputeAgentType)
+        .setRegistrationKey(registrationKey);
+    return new Promise(function(resolve, reject) {
+      that._disputeAgentsClient.registerDisputeAgent(request, {password: that._password}, function(err: grpcWeb.RpcError) {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+  
+  /**
    * Get the current market price per 1 XMR in the given currency.
    * 
    * @param {string} currencyCode - currency code (fiat or crypto) to get the price of
@@ -231,6 +250,7 @@ class HavenoDaemon {
       });
     });
   }
+
   /**
    * Get the user's balances.
    * 
@@ -547,26 +567,6 @@ class HavenoDaemon {
         else resolve();
       });
     });
-  }
-
-  /**
-   * Register as a dispute agent.
-   * 
-   * @param {string} disputeAgentType - type of the dispute agent, E.G. mediator, refundagent
-   * @param {string} registrationKey - registration key, must be DEV_PRIVILEGE_PRIV_KEY
-   */
-  async registerDisputeAgent(disputeAgentType: string, registrationKey: string): Promise<void> {
-    let that = this;
-    let request = new RegisterDisputeAgentRequest()
-        .setDisputeAgentType(disputeAgentType)
-        .setRegistrationKey(registrationKey);
-    return new Promise(function(resolve, reject) {
-      that._disputeAgentsClient.registerDisputeAgent(request, {password: that._password}, function(err: grpcWeb.RpcError) {
-        if (err) reject(err);
-        else resolve();
-      });
-    });
-
   }
 }
 

--- a/src/HavenoDaemon.ts
+++ b/src/HavenoDaemon.ts
@@ -1,7 +1,7 @@
 import {HavenoUtils} from "./HavenoUtils";
 import * as grpcWeb from 'grpc-web';
-import {GetVersionClient, PriceClient, WalletsClient, OffersClient, PaymentAccountsClient, TradesClient} from './protobuf/GrpcServiceClientPb';
-import {GetVersionRequest, GetVersionReply, MarketPriceRequest, MarketPriceReply, MarketPricesRequest, MarketPricesReply, MarketPriceInfo, GetBalancesRequest, GetBalancesReply, XmrBalanceInfo, GetOffersRequest, GetOffersReply, OfferInfo, GetPaymentAccountsRequest, GetPaymentAccountsReply, CreateCryptoCurrencyPaymentAccountRequest, CreateCryptoCurrencyPaymentAccountReply, CreateOfferRequest, CreateOfferReply, CancelOfferRequest, TakeOfferRequest, TakeOfferReply, TradeInfo, GetTradeRequest, GetTradeReply, GetTradesRequest, GetTradesReply, GetNewDepositSubaddressRequest, GetNewDepositSubaddressReply, ConfirmPaymentStartedRequest, ConfirmPaymentReceivedRequest, XmrTx, GetXmrTxsRequest, GetXmrTxsReply, XmrDestination, CreateXmrTxRequest, CreateXmrTxReply, RelayXmrTxRequest, RelayXmrTxReply} from './protobuf/grpc_pb';
+import {DisputeAgentsClient, GetVersionClient, PriceClient, WalletsClient, OffersClient, PaymentAccountsClient, TradesClient} from './protobuf/GrpcServiceClientPb';
+import {GetVersionRequest, GetVersionReply, MarketPriceRequest, MarketPriceReply, MarketPricesRequest, MarketPricesReply, MarketPriceInfo, GetBalancesRequest, GetBalancesReply, XmrBalanceInfo, GetOffersRequest, GetOffersReply, OfferInfo, GetPaymentAccountsRequest, GetPaymentAccountsReply, CreateCryptoCurrencyPaymentAccountRequest, CreateCryptoCurrencyPaymentAccountReply, CreateOfferRequest, CreateOfferReply, CancelOfferRequest, TakeOfferRequest, TakeOfferReply, TradeInfo, GetTradeRequest, GetTradeReply, GetTradesRequest, GetTradesReply, GetNewDepositSubaddressRequest, GetNewDepositSubaddressReply, ConfirmPaymentStartedRequest, ConfirmPaymentReceivedRequest, XmrTx, GetXmrTxsRequest, GetXmrTxsReply, XmrDestination, CreateXmrTxRequest, CreateXmrTxReply, RelayXmrTxRequest, RelayXmrTxReply, RegisterDisputeAgentRequest} from './protobuf/grpc_pb';
 import {PaymentAccount, AvailabilityResult} from './protobuf/pb_pb';
 const console = require('console');
 
@@ -22,6 +22,7 @@ class HavenoDaemon {
   _paymentAccountsClient: PaymentAccountsClient;
   _offersClient: OffersClient;
   _tradesClient: TradesClient;
+  _disputeAgentsClient: DisputeAgentsClient;
   
   /**
    * Construct a client connected to a Haveno daemon.
@@ -41,6 +42,7 @@ class HavenoDaemon {
     this._paymentAccountsClient = new PaymentAccountsClient(this._url);
     this._offersClient = new OffersClient(this._url);
     this._tradesClient = new TradesClient(this._url);
+    this._disputeAgentsClient = new DisputeAgentsClient(this._url);
   }
   
   /**
@@ -229,7 +231,6 @@ class HavenoDaemon {
       });
     });
   }
-
   /**
    * Get the user's balances.
    * 
@@ -546,6 +547,26 @@ class HavenoDaemon {
         else resolve();
       });
     });
+  }
+
+  /**
+   * Register as a dispute agent.
+   * 
+   * @param {string} disputeAgentType - type of the dispute agent, E.G. mediator, refundagent
+   * @param {string} registrationKey - registration key, must be DEV_PRIVILEGE_PRIV_KEY
+   */
+  async registerDisputeAgent(disputeAgentType: string, registrationKey: string): Promise<void> {
+    let that = this;
+    let request = new RegisterDisputeAgentRequest()
+        .setDisputeAgentType(disputeAgentType)
+        .setRegistrationKey(registrationKey);
+    return new Promise(function(resolve, reject) {
+      that._disputeAgentsClient.registerDisputeAgent(request, {password: that._password}, function(err: grpcWeb.RpcError) {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+
   }
 }
 


### PR DESCRIPTION
Implements arbitrator dispute agent registration in the haveno daemon tests. The tests no longer require manually starting arbitrator-desktop and registering as mediator / refund agent.

Resolves haveno-dex/haveno#188