### PR TITLE
Fix typescript compile due to missing ignore null operator

### DIFF
--- a/src/HavenoDaemon.ts
+++ b/src/HavenoDaemon.ts
@@ -337,7 +337,7 @@ class HavenoDaemon {
     return new Promise(function(resolve, reject) {
       that._walletsClient.createXmrTx(new CreateXmrTxRequest().setDestinationsList(destinations), {password: that._password}, function(err: grpcWeb.RpcError, response: CreateXmrTxReply) {
         if (err) reject(err);
-        else resolve(response.getTx());
+        else resolve(response.getTx()!);
       });
     });
   }


### PR DESCRIPTION
The createXrmTx function was causing compile errors. Looks like the pattern is to use the typescript non-null assertion operator.