### PR TITLE
Add API functions to start and stop local Monero node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/testdata
 backup.zip
 
 # production

--- a/src/HavenoDaemon.test.ts
+++ b/src/HavenoDaemon.test.ts
@@ -495,8 +495,8 @@ test("Can start and stop local Monero node", async() => {
 
     // expect successful start with custom settings
     let settings: MoneroNodeSettings = new MoneroNodeSettings();
-    let dataDir = rootDir + "/testblockchain";
-    let logFile = rootDir + "/testblockchain/test.log";
+    let dataDir = rootDir + "/testdata";
+    let logFile = rootDir + "/testdata/test.log";
     let p2pPort = 58080;
     let rpcPort = 58081;
     settings.setBlockchainpath(dataDir);

--- a/src/HavenoDaemon.ts
+++ b/src/HavenoDaemon.ts
@@ -612,13 +612,13 @@ class HavenoDaemon {
   /**
    * Gets the current local monero node settings.
    */
-  async getMoneroNodeSettings(): Promise<MoneroNodeSettings> {
+  async getMoneroNodeSettings(): Promise<MoneroNodeSettings | undefined> {
     let that = this;
     return new Promise(function(resolve, reject) {
       let request = new GetMoneroNodeSettingsRequest();
       that._moneroNodeClient.getMoneroNodeSettings(request, {password: that._password}, function(err: grpcWeb.RpcError, response: GetMoneroNodeSettingsReply) {
         if (err) reject(err);
-        else resolve(response.getSettings()!);
+        else resolve(response.getSettings());
       });
     });
   }


### PR DESCRIPTION
Tests the startMoneroNode and stopMoneroNode functionality. The test attempts to exercise a scenario where the local node's port has been occupied by starting an httpserver and listening to the known port. Note that rapidly repeating the test may result in a broken state which I haven't been able to figure out, I suspect its related to the node js implementation of the `net.createServer()` object. The test ensures the wallet balance can still be fetched after starting the local node and verifying that the current Monero daemon connection has been unset.
 
Resolves haveno-dex/haveno#137