### PR TITLE
Add API functions to support trade chat

### DIFF
--- a/src/HavenoDaemon.test.ts
+++ b/src/HavenoDaemon.test.ts
@@ -1844,7 +1844,7 @@ async function testTradeChat(tradeId: string, alice: HavenoDaemon, bob: HavenoDa
   await wait(TestConfig.maxTimePeerNoticeMs);
   messages = await bob.getChatMessages(tradeId);
   let offset = 3; // 3 existing messages
-  expect(messages.length).toEqual(offset+msgs.length);
+  expect(messages.length).toEqual(offset + msgs.length);
   expect(messages[0].getIsSystemMessage()).toEqual(true);
   expect(messages[1].getMessage()).toEqual(aliceMsg);
   expect(messages[2].getMessage()).toEqual(bobMsg);
@@ -1854,7 +1854,7 @@ async function testTradeChat(tradeId: string, alice: HavenoDaemon, bob: HavenoDa
 
   chatNotifications = getNotifications(bobNotifications, NotificationMessage.NotificationType.CHAT_MESSAGE);
   offset = 1; // 1 existing notification
-  expect(chatNotifications.length).toBe(offset+msgs.length);
+  expect(chatNotifications.length).toBe(offset + msgs.length);
   expect(chatNotifications[0].getChatMessage()?.getMessage()).toEqual(aliceMsg);
   for (var i = 0; i < msgs.length; i++) {
     expect(chatNotifications[i + offset].getChatMessage()?.getMessage()).toEqual(msgs[i]);

--- a/src/HavenoDaemon.test.ts
+++ b/src/HavenoDaemon.test.ts
@@ -880,7 +880,8 @@ test("Can complete a trade", async () => {
   fetchedTrade = await alice.getTrade(trade.getTradeId());
   expect(fetchedTrade.getPhase()).toEqual("DEPOSIT_PUBLISHED");
 
-  await testTradeChat(trade.getTradeId(), alice, bob); // test trader chat
+  // test trader chat
+  await testTradeChat(trade.getTradeId(), alice, bob);
   
   // mine until deposit txs unlock
   HavenoUtils.log(1, "Mining to unlock deposit txs");

--- a/src/HavenoDaemon.test.ts
+++ b/src/HavenoDaemon.test.ts
@@ -880,7 +880,7 @@ test("Can complete a trade", async () => {
   fetchedTrade = await alice.getTrade(trade.getTradeId());
   expect(fetchedTrade.getPhase()).toEqual("DEPOSIT_PUBLISHED");
 
-  await testTradeChat(trade.getTradeId(), alice, bob);
+  await testTradeChat(trade.getTradeId(), alice, bob); // test trader chat
   
   // mine until deposit txs unlock
   HavenoUtils.log(1, "Mining to unlock deposit txs");
@@ -1857,7 +1857,6 @@ async function testTradeChat(tradeId: string, alice: HavenoDaemon, bob: HavenoDa
   expect(chatNotifications.length).toBe(offset+msgs.length);
   expect(chatNotifications[0].getChatMessage()?.getMessage()).toEqual(aliceMsg);
   for (var i = 0; i < msgs.length; i++) {
-    // notifications messages are trimmed
-    expect(chatNotifications[i+offset].getChatMessage()?.getMessage()).toEqual(msgs[i].trim());
+    expect(chatNotifications[i + offset].getChatMessage()?.getMessage()).toEqual(msgs[i]);
   }
 }

--- a/src/HavenoDaemon.ts
+++ b/src/HavenoDaemon.ts
@@ -2,8 +2,8 @@ import {HavenoUtils} from "./utils/HavenoUtils";
 import {TaskLooper} from "./utils/TaskLooper";
 import * as grpcWeb from 'grpc-web';
 import {GetVersionClient, AccountClient, MoneroConnectionsClient, DisputesClient, DisputeAgentsClient, NotificationsClient, WalletsClient, PriceClient, OffersClient, PaymentAccountsClient, TradesClient, ShutdownServerClient} from './protobuf/GrpcServiceClientPb';
-import {GetVersionRequest, GetVersionReply, IsAppInitializedRequest, IsAppInitializedReply, RegisterDisputeAgentRequest, MarketPriceRequest, MarketPriceReply, MarketPricesRequest, MarketPricesReply, MarketPriceInfo, MarketDepthRequest, MarketDepthReply, MarketDepthInfo, GetBalancesRequest, GetBalancesReply, XmrBalanceInfo, GetMyOfferRequest, GetMyOfferReply, GetOffersRequest, GetOffersReply, OfferInfo, GetPaymentMethodsRequest, GetPaymentMethodsReply, GetPaymentAccountFormRequest, CreatePaymentAccountRequest, CreatePaymentAccountReply, GetPaymentAccountFormReply, GetPaymentAccountsRequest, GetPaymentAccountsReply, CreateCryptoCurrencyPaymentAccountRequest, CreateCryptoCurrencyPaymentAccountReply, CreateOfferRequest, CreateOfferReply, CancelOfferRequest, TakeOfferRequest, TakeOfferReply, TradeInfo, GetTradeRequest, GetTradeReply, GetTradesRequest, GetTradesReply, GetNewDepositSubaddressRequest, GetNewDepositSubaddressReply, ConfirmPaymentStartedRequest, ConfirmPaymentReceivedRequest, XmrTx, GetXmrTxsRequest, GetXmrTxsReply, XmrDestination, CreateXmrTxRequest, CreateXmrTxReply, RelayXmrTxRequest, RelayXmrTxReply, CreateAccountRequest, AccountExistsRequest, AccountExistsReply, DeleteAccountRequest, OpenAccountRequest, IsAccountOpenRequest, IsAccountOpenReply, CloseAccountRequest, ChangePasswordRequest, BackupAccountRequest, BackupAccountReply, RestoreAccountRequest, StopRequest, NotificationMessage, RegisterNotificationListenerRequest, SendNotificationRequest, UrlConnection, AddConnectionRequest, RemoveConnectionRequest, GetConnectionRequest, GetConnectionsRequest, SetConnectionRequest, CheckConnectionRequest, CheckConnectionsReply, CheckConnectionsRequest, StartCheckingConnectionsRequest, StopCheckingConnectionsRequest, GetBestAvailableConnectionRequest, SetAutoSwitchRequest, CheckConnectionReply, GetConnectionsReply, GetConnectionReply, GetBestAvailableConnectionReply, GetDisputeRequest, GetDisputeReply, GetDisputesRequest, GetDisputesReply, OpenDisputeRequest, ResolveDisputeRequest, SendDisputeChatMessageRequest} from './protobuf/grpc_pb';
-import {PaymentMethod, PaymentAccount, AvailabilityResult, Attachment, DisputeResult, Dispute} from './protobuf/pb_pb';
+import {GetVersionRequest, GetVersionReply, IsAppInitializedRequest, IsAppInitializedReply, RegisterDisputeAgentRequest, MarketPriceRequest, MarketPriceReply, MarketPricesRequest, MarketPricesReply, MarketPriceInfo, MarketDepthRequest, MarketDepthReply, MarketDepthInfo, GetBalancesRequest, GetBalancesReply, XmrBalanceInfo, GetMyOfferRequest, GetMyOfferReply, GetOffersRequest, GetOffersReply, OfferInfo, GetPaymentMethodsRequest, GetPaymentMethodsReply, GetPaymentAccountFormRequest, CreatePaymentAccountRequest, CreatePaymentAccountReply, GetPaymentAccountFormReply, GetPaymentAccountsRequest, GetPaymentAccountsReply, CreateCryptoCurrencyPaymentAccountRequest, CreateCryptoCurrencyPaymentAccountReply, CreateOfferRequest, CreateOfferReply, CancelOfferRequest, TakeOfferRequest, TakeOfferReply, TradeInfo, GetTradeRequest, GetTradeReply, GetTradesRequest, GetTradesReply, GetNewDepositSubaddressRequest, GetNewDepositSubaddressReply, ConfirmPaymentStartedRequest, ConfirmPaymentReceivedRequest, XmrTx, GetXmrTxsRequest, GetXmrTxsReply, XmrDestination, CreateXmrTxRequest, CreateXmrTxReply, RelayXmrTxRequest, RelayXmrTxReply, CreateAccountRequest, AccountExistsRequest, AccountExistsReply, DeleteAccountRequest, OpenAccountRequest, IsAccountOpenRequest, IsAccountOpenReply, CloseAccountRequest, ChangePasswordRequest, BackupAccountRequest, BackupAccountReply, RestoreAccountRequest, StopRequest, NotificationMessage, RegisterNotificationListenerRequest, SendNotificationRequest, UrlConnection, AddConnectionRequest, RemoveConnectionRequest, GetConnectionRequest, GetConnectionsRequest, SetConnectionRequest, CheckConnectionRequest, CheckConnectionsReply, CheckConnectionsRequest, StartCheckingConnectionsRequest, StopCheckingConnectionsRequest, GetBestAvailableConnectionRequest, SetAutoSwitchRequest, CheckConnectionReply, GetConnectionsReply, GetConnectionReply, GetBestAvailableConnectionReply, GetDisputeRequest, GetDisputeReply, GetDisputesRequest, GetDisputesReply, OpenDisputeRequest, ResolveDisputeRequest, SendDisputeChatMessageRequest, SendChatMessageRequest, GetChatMessagesRequest, GetChatMessagesReply} from './protobuf/grpc_pb';
+import {PaymentMethod, PaymentAccount, AvailabilityResult, Attachment, DisputeResult, Dispute, ChatMessage} from './protobuf/pb_pb';
 
 const console = require('console');
 
@@ -1021,6 +1021,41 @@ class HavenoDaemon {
     let that = this;
     return new Promise(function(resolve, reject) {
       that._tradesClient.confirmPaymentReceived(new ConfirmPaymentReceivedRequest().setTradeId(tradeId), {password: that._password}, function(err: grpcWeb.RpcError) {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+
+  /**
+   * Get all chat messages for a trade.
+   *
+   * @param {string} tradeId
+   */
+  async getChatMessages(tradeId: string): Promise<ChatMessage[]> {
+    let that = this;
+    return new Promise(function(resolve, reject) {
+      let request = new GetChatMessagesRequest().setTradeId(tradeId);
+      that._tradesClient.getChatMessages(request, {password: that._password}, function(err: grpcWeb.RpcError, response: GetChatMessagesReply) {
+        if (err) reject(err);
+        else resolve(response.getMessageList());
+      });
+    });
+  }
+
+  /**
+   * Send a trade chat message.
+   *
+   * @param {string} tradeId - the id of the trade
+   * @param {string} message - the message
+   */
+  async sendChatMessage(tradeId: string, message: string): Promise<void> {
+    let that = this;
+    return new Promise(function(resolve, reject) {
+      let request = new SendChatMessageRequest()
+            .setTradeId(tradeId)
+            .setMessage(message);
+      that._tradesClient.sendChatMessage(request, {password: that._password}, function(err: grpcWeb.RpcError) {
         if (err) reject(err);
         else resolve();
       });

--- a/src/HavenoDaemon.ts
+++ b/src/HavenoDaemon.ts
@@ -1030,7 +1030,7 @@ class HavenoDaemon {
   /**
    * Get all chat messages for a trade.
    *
-   * @param {string} tradeId
+   * @param {string} tradeId - the id of the trade
    */
   async getChatMessages(tradeId: string): Promise<ChatMessage[]> {
     let that = this;


### PR DESCRIPTION
Tests trade chat API functionality to resolve  haveno-dex/haveno#142.

The trade chat testing is added to the `Can complete a trade` test.  There is an additional sleep between message sends due to the async nature of the functions which was also required for the dispute chat test. I also discovered white space messages were trimmed from the notifications, but not from the daemon API.