### PR TITLE
Fix a missing void type argument to Promise

### DIFF
--- a/src/HavenoDaemon.ts
+++ b/src/HavenoDaemon.ts
@@ -275,7 +275,7 @@ class HavenoDaemon {
    */
   async createAccount(password: string): Promise<void> {
     let that = this;
-    await new Promise(function(resolve, reject) {
+    await new Promise<void>(function(resolve, reject) {
       that._accountClient.createAccount(new CreateAccountRequest().setPassword(password), {password: that._password}, function(err: grpcWeb.RpcError) {
         if (err) reject(err);
         else resolve();
@@ -291,7 +291,7 @@ class HavenoDaemon {
    */
   async openAccount(password: string): Promise<void> {
     let that = this;
-    await new Promise(function(resolve, reject) {
+    await new Promise<void>(function(resolve, reject) {
       that._accountClient.openAccount(new OpenAccountRequest().setPassword(password), {password: that._password}, function(err: grpcWeb.RpcError) {
         if (err) reject(err);
         else resolve();
@@ -1158,7 +1158,7 @@ class HavenoDaemon {
   async shutdownServer() {
     if (this._keepAliveLooper) this._keepAliveLooper.stop();
     let that = this;
-    await new Promise(function(resolve, reject) {
+    await new Promise<void>(function(resolve, reject) {
       that._shutdownServerClient.stop(new StopRequest(), {password: that._password}, function(err: grpcWeb.RpcError) { // process receives 'exit' event
         if (err) reject(err);
         else resolve();


### PR DESCRIPTION
Fixes the error
```
Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?  TS2794
```
at lines `278`, `294` and `1161` in the file `src/HavenoDaemon.ts` by adding said `void` in the type argument as suggested by this error.