### PR TITLE
Add Typedocs to automate docs generating.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 
 # generated code
 /src/protobuf/**
+
+# generated docs
+/docs

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test": "react-scripts test --runInBand",
     "eject": "react-scripts eject",
     "prepare": "bin/build_protobuf.sh",
-    "pretest": "bin/build_protobuf.sh"
+    "pretest": "bin/build_protobuf.sh",
+    "generate:docs": "typedoc ./src/haveno.ts --exclude **/*.test.ts --excludeNotDocumented"
   },
   "eslintConfig": {
     "extends": [
@@ -49,6 +50,7 @@
     ]
   },
   "devDependencies": {
-    "monero-javascript": "^0.6.4"
+    "monero-javascript": "^0.6.4",
+    "typedoc": "^0.22.15"
   }
 }


### PR DESCRIPTION
Added Typedocs to automate docs generation of HavenoClient library, unfortunately. the library and its test file have some TS errors which cause some errors when starting `generate:docs` command, even if the `.test.ts|js` files are excluded from Typedocs, cause Typedocs try to run all TS files in tsc, so to prevent these errors temporarily just add `@ts-nocheck` in the header of `haveno.ts` and `haveno.test.ts` and the generator would work fine. By the way in the old version of Typedocs has  `--ignoreCompilerErrors` option but they removed it in the latest versions.
https://github.com/TypeStrong/typedoc/issues/1643